### PR TITLE
Add script to move & symlink epochs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,9 @@ PYTHONPATH=. python3 ./archive_py/download.py --folder=~/db-downloads --url=${UR
 ```
 PYTHONPATH=. python3 ./archive_py/extract.py --input-folder=~/db-downloads --output-folder=~/db-extracted
 ```
+
+## Move & symlink epoch folders
+
+```
+PYTHONPATH=. python3 ./archive_py/move_link_epochs.py --input-folder=~/db/T --output-folder=~/place/db/T
+```

--- a/archive_py/move_link_epochs.py
+++ b/archive_py/move_link_epochs.py
@@ -1,0 +1,63 @@
+import os
+import shutil
+from argparse import ArgumentParser
+from pathlib import Path
+
+from archive_py.constants import HELP_STRING_DB
+from archive_py.io import ensure_folder
+from archive_py.ux import ask_number, confirm_continuation
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("--input-folder", required=True, help=HELP_STRING_DB)
+    parser.add_argument("--output-folder", required=True, help=HELP_STRING_DB)
+    args = parser.parse_args()
+
+    input_folder = Path(args.input_folder).expanduser()
+    output_folder = Path(args.output_folder).expanduser()
+
+    ensure_folder(output_folder)
+
+    print("Input folder:", input_folder)
+    print("Output folder:", output_folder)
+
+    confirm_continuation()
+
+    first_epoch_to_move = find_first_movable_epoch(input_folder)
+    print("First epoch to move:", first_epoch_to_move)
+    confirm_continuation()
+
+    num_epochs_to_move = ask_number(f"""How many epochs to move
+\tfrom {input_folder}
+\tto {output_folder}?""")
+    last_epoch_to_move = first_epoch_to_move + num_epochs_to_move
+    epochs_to_move = list(range(first_epoch_to_move, last_epoch_to_move))
+
+    print("Epochs to move:", epochs_to_move)
+
+    confirm_continuation()
+
+    for epoch in epochs_to_move:
+        print("Moving epoch", epoch)
+        confirm_continuation()
+
+        source = input_folder / f"Epoch_{epoch}"
+        destination = output_folder / f"Epoch_{epoch}"
+        shutil.move(str(source), destination)
+        os.symlink(destination, source)
+
+
+def find_first_movable_epoch(folder: Path) -> int:
+    epoch = 0
+
+    while True:
+        epoch_folder = folder / f"Epoch_{epoch}"
+        if epoch_folder.is_dir() and not epoch_folder.is_symlink():
+            return epoch
+
+        epoch += 1
+
+
+if __name__ == "__main__":
+    main()

--- a/archive_py/move_link_epochs.py
+++ b/archive_py/move_link_epochs.py
@@ -40,7 +40,6 @@ def main():
 
     for epoch in epochs_to_move:
         print("Moving epoch", epoch)
-        confirm_continuation()
 
         source = input_folder / f"Epoch_{epoch}"
         if not is_movable(source):

--- a/archive_py/move_link_epochs.py
+++ b/archive_py/move_link_epochs.py
@@ -43,6 +43,10 @@ def main():
         confirm_continuation()
 
         source = input_folder / f"Epoch_{epoch}"
+        if not is_movable(source):
+            print("Not movable. Will stop here.")
+            break
+
         destination = output_folder / f"Epoch_{epoch}"
         shutil.move(str(source), destination)
         os.symlink(destination, source)
@@ -53,10 +57,14 @@ def find_first_movable_epoch(folder: Path) -> int:
 
     while True:
         epoch_folder = folder / f"Epoch_{epoch}"
-        if epoch_folder.is_dir() and not epoch_folder.is_symlink():
+        if is_movable(epoch_folder):
             return epoch
 
         epoch += 1
+
+
+def is_movable(folder: Path) -> bool:
+    return folder.is_dir() and not folder.is_symlink()
 
 
 if __name__ == "__main__":

--- a/archive_py/ux.py
+++ b/archive_py/ux.py
@@ -6,3 +6,8 @@ def confirm_continuation(yes: bool = False):
     if answer.lower() not in ["y", "yes"]:
         print("Confirmation not given. Will stop.")
         exit(1)
+
+
+def ask_number(message: str):
+    answer = input(f"{message}\n")
+    return int(answer)


### PR DESCRIPTION
Sometimes, it's more costly-efficient to hold node's db on different partitions (e.g. HDD for older epochs, SSD for `Static` and newer epochs).

This new scripts allows one to move epoch folders from a `db/chainID` folder to a separate location, and create symlink towards the new location.